### PR TITLE
Fix comment grammar in Vite server file

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -52,7 +52,7 @@ export async function setupVite(app: Express, server: Server) {
         "index.html",
       );
 
-      // always reload the index.html file from disk incase it changes
+      // always reload the index.html file from disk in case it changes.
       let template = await fs.promises.readFile(clientTemplate, "utf-8");
       template = template.replace(
         `src="/src/main.tsx"`,


### PR DESCRIPTION
## Summary
- correct comment in `server/vite.ts` referring to reloading index.html

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_b_6839f48b2d9c83308ff9917650aca26c