### PR TITLE
Update docs and test URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The Caretaker Prompt Generator is a specialized healthcare monitoring tool desig
    ```
 
 2. **Access the application**:
-   - Open your browser and navigate to `http://localhost:3000`
+   - Open your browser and navigate to `http://localhost:5000`
    - The application should be running and ready for use
 
 ## Usage Guide

--- a/test-webhook.js
+++ b/test-webhook.js
@@ -4,7 +4,7 @@ async function testWebhook() {
   try {
     console.log("🧪 Testing webhook endpoint...");
     
-    const response = await fetch("http://localhost:4000/api/vapi/webhook/test", {
+    const response = await fetch("http://localhost:5000/api/vapi/webhook/test", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -18,7 +18,7 @@ async function testWebhook() {
       
       // Now check if the call was stored
       console.log("\n🔍 Checking call history...");
-      const callHistoryResponse = await fetch("http://localhost:4000/api/call-history");
+      const callHistoryResponse = await fetch("http://localhost:5000/api/call-history");
       
       if (callHistoryResponse.ok) {
         const callHistoryData = await callHistoryResponse.json();


### PR DESCRIPTION
## Summary
- update local server URL in README
- update webhook test URLs to new port

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_683a00c7464c83309d5dd382395ddfb0