### PR TITLE
Fix outdated comment in storage.ts

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1313,7 +1313,6 @@ IMPORTANT: You have access to their latest health data and personalized care rec
     return await query.orderBy(desc(callHistory.callDate));
   }
 
-  // Need to import the and function at the top
   async getAllCallHistory(limit?: number, offset?: number): Promise<CallHistory[]> {
     let query = db
       .select()


### PR DESCRIPTION
## Summary
- remove incorrect comment about importing `and`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_683a00b650dc8330b995e50db2a8289d