### PR TITLE
Consolidate getAllCallHistory method

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -81,7 +81,7 @@ export interface IStorage {
   getCallHistoryByPatient(patientId: string, limit?: number, offset?: number): Promise<CallHistory[]>;
   getLatestCallForPatient(patientId: string): Promise<CallHistory | null>;
   updateCallHistory(callId: string, updates: Partial<InsertCallHistory>): Promise<CallHistory>;
-  getAllCallHistory(): Promise<CallHistory[]>;
+  getAllCallHistory(limit?: number, offset?: number): Promise<CallHistory[]>;
 
   // Voice agent template methods
   getVoiceAgentTemplate(): Promise<string>;
@@ -1171,13 +1171,6 @@ Your Healthcare Provider`;
       .where(eq(callHistory.callId, callId))
       .returning();
     return updatedCall;
-  }
-
-  async getAllCallHistory(): Promise<CallHistory[]> {
-    return await db
-      .select()
-      .from(callHistory)
-      .orderBy(desc(callHistory.callDate));
   }
 
   // Voice agent template methods


### PR DESCRIPTION
## Summary
- add optional `limit` and `offset` parameters to `IStorage.getAllCallHistory`
- remove duplicate `getAllCallHistory` implementation

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_683a00afaf9483309acb01c78a56f330