### PR TITLE
Fix triage batch caching

### DIFF
--- a/client/src/pages/AIPoweredTriage.tsx
+++ b/client/src/pages/AIPoweredTriage.tsx
@@ -130,7 +130,7 @@ export default function AIPoweredTriage() {
       return data.success && data.data ? data.data : null;
     },
     retry: 2,
-    staleTime: 30000 // Cache for 30 seconds
+    staleTime: 0 // Always fetch the latest batch
   });
 
   // Get all batches - only run if latest batch doesn't have prompts
@@ -143,7 +143,7 @@ export default function AIPoweredTriage() {
       return data.success && data.data ? data.data : [];
     },
     retry: 2,
-    staleTime: 30000 // Cache for 30 seconds
+    staleTime: 0 // Always fetch the latest list of batches
   });
 
   // Check if latest batch has prompts
@@ -164,7 +164,7 @@ export default function AIPoweredTriage() {
     },
     enabled: !!latestBatch?.batchId,
     retry: 1,
-    staleTime: 30000
+    staleTime: 0
   });
 
   // Find batch with prompts (only if latest doesn't have prompts)
@@ -196,7 +196,7 @@ export default function AIPoweredTriage() {
       !isCheckingLatestBatch
     ),
     retry: 1,
-    staleTime: 30000
+    staleTime: 0
   });
 
   // Determine the effective batch ID using a more predictable approach


### PR DESCRIPTION
## Summary
- always fetch latest batch information on triage page

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_684c274ab95c8330b74cf601a801ff9e