### PR TITLE
Fix DB init circular dependency

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -7,7 +7,6 @@ import * as schema from "@shared/schema";
 neonConfig.webSocketConstructor = ws;
 
 // Import initialization function
-import { initializeDatabase } from './lib/initDb';
 
 // Declare db with the specific NeonDatabase type
 let db: NeonDatabase<typeof schema>;
@@ -30,13 +29,6 @@ try {
   db = drizzle(pool, { schema });
   console.log("Neon database client initialized successfully");
   
-  // Initialize database tables (runs asynchronously)
-  initializeDatabase().then(() => {
-    console.log("Database tables initialized successfully");
-  }).catch(err => {
-    console.error("Failed to initialize database tables:", err);
-    // Optionally, decide if startup should fail here
-  });
 
 } catch (err) {
   console.error("Failed to initialize database client:", err);

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,7 @@
 import express, { type Request, Response, NextFunction } from "express";
 import { setupRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
+import { db } from "./db";
 import cors from 'cors';
 import { initializeDatabase } from "./lib/initDb";
 
@@ -83,7 +84,7 @@ app.use((req, res, next) => {
 
   // Initialize database
   try {
-    await initializeDatabase();
+    await initializeDatabase(db);
   } catch (err) {
     console.error('Failed to initialize database:', err);
     process.exit(1);

--- a/server/lib/initDb.ts
+++ b/server/lib/initDb.ts
@@ -1,5 +1,6 @@
 
-import { db } from '../db';
+import type { NeonDatabase } from 'drizzle-orm/neon-serverless';
+import * as schema from '@shared/schema';
 import { users, patientBatches, patientPrompts } from '@shared/schema';
 import { sql } from 'drizzle-orm';
 import { scrypt, randomBytes } from 'crypto';
@@ -19,7 +20,7 @@ async function hashPassword(password: string): Promise<string> {
 /**
  * Initialize database tables and add a test user if needed
  */
-export async function initializeDatabase() {
+export async function initializeDatabase(db: NeonDatabase<typeof schema>) {
   try {
     console.log('Database client initialized successfully');
     


### PR DESCRIPTION
## Summary
- prevent circular import between `initDb` and `db`
- pass DB instance to `initializeDatabase`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_684c26f425188330b68a4af1ee4a3aa7