### PR TITLE
Add Trend Report Prompt Features

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -97,11 +97,23 @@ export const patientSystemPrompts = pgTable("patient_system_prompts", {
   updatedAt: text("updated_at"),
 });
 
+export const trendSystemPrompts = pgTable("trend_system_prompts", {
+  id: serial("id").primaryKey(),
+  batchId: text("batch_id"),
+  prompt: text("prompt").notNull(),
+  createdAt: text("created_at").default(new Date().toISOString()),
+  updatedAt: text("updated_at"),
+});
+
 export const insertSystemPromptSchema = createInsertSchema(systemPrompts).omit({
   id: true,
 });
 
 export const insertPatientSystemPromptSchema = createInsertSchema(patientSystemPrompts).omit({
+  id: true,
+});
+
+export const insertTrendSystemPromptSchema = createInsertSchema(trendSystemPrompts).omit({
   id: true,
 });
 
@@ -132,6 +144,9 @@ export type InsertSystemPrompt = z.infer<typeof insertSystemPromptSchema>;
 
 export type PatientSystemPrompt = typeof patientSystemPrompts.$inferSelect;
 export type InsertPatientSystemPrompt = z.infer<typeof insertPatientSystemPromptSchema>;
+
+export type TrendSystemPrompt = typeof trendSystemPrompts.$inferSelect;
+export type InsertTrendSystemPrompt = z.infer<typeof insertTrendSystemPromptSchema>;
 
 export type TemplateVariable = typeof templateVariables.$inferSelect;
 export type InsertTemplateVariable = z.infer<


### PR DESCRIPTION
## Summary
- add new `trendSystemPrompts` table and types
- support trend system prompt CRUD in storage and routes
- implement trend report prompt generation with GPT-4.1 nano
- show generated trend report text in Trend Reports page
- allow editing trend report prompt in Prompt Editing sandbox

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_684c1b0ad928833082f09e0681821f75